### PR TITLE
G3-347: Switching Auth tenant to thejacksonlaboratory

### DIFF
--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: geneweaver-legacy-config
 data:
-  AUTH_CLIENTID: "wMjx3nGV24qneBjXqz52IhEpq6AU7reo"
+  AUTH_CLIENTID: "x9IiBRyt8lS3lsqrz2H6aO1leRBbxyb7"
   APPLICATION_RESULTS: "/var/geneweaver/results"
   CELERY_HOST: "redis-master"
   CELERY_PORT: "6379"

--- a/deploy/k8s/overlays/jax-cluster-prod-10--prod/configmap.yaml
+++ b/deploy/k8s/overlays/jax-cluster-prod-10--prod/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: geneweaver-legacy-config
+data:
+  AUTH_CLIENTID: "5X9TlYZWVN3Ox9cVNpn2BEW3zhpFA1i1"

--- a/deploy/k8s/overlays/jax-cluster-prod-10--prod/kustomization.yaml
+++ b/deploy/k8s/overlays/jax-cluster-prod-10--prod/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ingress.yaml
 patchesStrategicMerge:
   - persistent-volume-claim.yaml
+  - configmap.yaml

--- a/deploy/k8s/overlays/jax-cluster-prod-10--stage/configmap.yaml
+++ b/deploy/k8s/overlays/jax-cluster-prod-10--stage/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: geneweaver-legacy-config
+data:
+  AUTH_CLIENTID: "5X9TlYZWVN3Ox9cVNpn2BEW3zhpFA1i1"

--- a/deploy/k8s/overlays/jax-cluster-prod-10--stage/kustomization.yaml
+++ b/deploy/k8s/overlays/jax-cluster-prod-10--stage/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ingress.yaml
 patchesStrategicMerge:
   - persistent-volume-claim.yaml
+  - configmap.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-legacy"
-version = "1.3.5"
+version = "1.4.0"
 description = ""
 authors = ["Alexander Berger <alexander.berger@jax.org>"]
 readme = "README.md"

--- a/src/config.py
+++ b/src/config.py
@@ -69,9 +69,9 @@ class LandingPage(BaseModel):
 
 
 class Auth(BaseModel):
-    client_id: str = Field("wMjx3nGV24qneBjXqz52IhEpq6AU7reo", validation_alias="clientid")
+    client_id: str = Field("x9IiBRyt8lS3lsqrz2H6aO1leRBbxyb7", validation_alias="clientid")
     client_secret: str = Field("", validation_alias="clientsecret")
-    domain: str = "geneweaver.auth0.com"
+    domain: str = "thejacksonlaboratory.auth0.com"
     auth_endpoint: str = Field("authorize", validation_alias="authendpoint")
     token_endpoint: str = Field("oauth/token", validation_alias="tokenendpoint")
     userinfo_endpoint: str = Field("oauth/userinfo", validation_alias="userinfoendpoint")


### PR DESCRIPTION
This PR changes the authentication backend for the Geneweaver website. Users should experience a seamless transition, and no further action should be required.

If a user runs into issues with their password, they should use the password reset functionality.

If a user runs into any other issues logging in, they should contact the Geneweaver team. 