### PR TITLE
G3-457: Fix geneset has no hom_ids KeyError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-legacy"
-version = "1.4.6"
+version = "1.4.7"
 description = ""
 authors = ["Alexander Berger <alexander.berger@jax.org>"]
 readme = "README.md"

--- a/src/application.py
+++ b/src/application.py
@@ -3226,7 +3226,8 @@ def calculate_jaccard(gs_id, genesets):
     gs1 = geneweaverdb.get_geneset_hom_ids(gs_id)
     gs2s = geneweaverdb.get_genesets_hom_ids(genesets)
     for g in genesets:
-        jaccards[g] = jaccard(gs1, gs2s[g])
+        if g in gs2s:
+            jaccards[g] = jaccard(gs1, gs2s[g])
     return jaccards
 
 


### PR DESCRIPTION
This fixes the case where requested genesets don't have any hom_ids.